### PR TITLE
Add version selection for docs download

### DIFF
--- a/docs_converter/download_docs.py
+++ b/docs_converter/download_docs.py
@@ -7,10 +7,43 @@ import os
 import shutil
 import urllib.request
 import zipfile
+import requests
 
 def download_repo():
     """Download godot-docs ZIP file and extract to docs folder"""
-    zip_url = "https://github.com/godotengine/godot-docs/archive/refs/heads/master.zip"
+
+    
+    versions = None
+
+    try:
+        print("Fetching available versions from GitHub API...\n")
+        response = requests.get(
+            "https://api.github.com/repos/godotengine/godot-docs/branches",
+            timeout=10
+        )
+
+        if response.status_code == 200:
+            branches = response.json()
+            versions = [b["name"] for b in branches]
+
+            print("Available versions:")
+            for v in versions:
+                print(f"- {v}")
+
+    except Exception as e:
+        print(f"Could not fetch versions from GitHub API: {e}")
+
+    # unified input handling (ONLY ONCE)
+    version = input("Enter version (press Enter for latest): ").strip()
+
+    if not version:
+        version = "master"
+
+    elif versions and version not in versions:
+        print(f"Invalid version '{version}', falling back to master")
+        version = "master"
+
+    zip_url = f"https://github.com/godotengine/godot-docs/archive/refs/heads/{version}.zip"
     zip_file = "godot-docs.zip"
     docs_dir = "docs"
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.md"
 requires-python = ">=3.13.5"
 dependencies = [
     "fastmcp>=2.10.6",
-    "pypandoc>=1.15"
+    "pypandoc>=1.15",
+    "requests>=2.34.2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary
This PR enhances the documentation download functionality by adding interactive version selection from the Godot docs repository.

## Changes
- **docs_converter/download_docs.py**: Added GitHub API integration to fetch available branches and allow users to select which version of the docs to download
  - Fetches available versions from the GitHub API
  - Prompts user for version selection with fallback to 'master'
  - Validates user input against available versions
  
- **pyproject.toml**: Added `requests>=2.34.2` as a new dependency for HTTP requests

## Benefits
- Users can now download docs for different Godot versions, not just the latest master branch
- Improved user experience with version discovery and validation